### PR TITLE
Reduce memory allocation by 80%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,5 +150,17 @@
 			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.36</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.36</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/JaroWinklerSimilarity.java
+++ b/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/JaroWinklerSimilarity.java
@@ -236,11 +236,12 @@ public class JaroWinklerSimilarity<T> implements Function<String, Map<T, Double>
 				} else {
 					// iterate children
 					Iterator<? extends Trie<R>> children = termTrie.childrenIterator();
-
+					boolean[] termAssignedCopy = new boolean[termTargetLength];
+					boolean[] queryAssignedCopy = new boolean[queryLength];
 					while (children.hasNext()) {
 
-						boolean[] termAssignedCopy = Arrays.copyOf(assignedTerm, termTargetLength);
-						boolean[] queryAssignedCopy = Arrays.copyOf(assignedQuery, queryLength);
+						System.arraycopy(assignedTerm, 0, termAssignedCopy, 0, termTargetLength);
+						System.arraycopy(assignedQuery, 0, queryAssignedCopy, 0, queryLength);
 
 						Trie<R> child = children.next();
 

--- a/src/test/java/de/uni_jena/cs/fusion/similarity/jarowinkler/JaroWinklerSimilarityBenchmark.java
+++ b/src/test/java/de/uni_jena/cs/fusion/similarity/jarowinkler/JaroWinklerSimilarityBenchmark.java
@@ -1,0 +1,99 @@
+package de.uni_jena.cs.fusion.similarity.jarowinkler;
+
+/*-
+ * #%L
+ * Jaro Winkler Similarity
+ * %%
+ * Copyright (C) 2018 - 2023 Heinz Nixdorf Chair for Distributed Information Systems, Friedrich Schiller University Jena
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Benchmark of the {@link JaroWinklerSimilarity} that measures throughput and GC metrics.
+ */
+public class JaroWinklerSimilarityBenchmark {
+    private static final String DATASET_PATH = "dataset1/dbpedia_2016-10_persondata_en_names_unique_sorted.gz";
+    private static final int QUERIES_SAMPLE_SIZE = 1000;
+    private static final double SIMILARITY_THRESHOLD = 0.95;
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(JaroWinklerSimilarityBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    @Warmup(iterations = 3)
+    @Measurement(iterations = 3)
+    public void benchmark(Blackhole bh, BenchmarkState state) {
+        for (String query : state.queriesSample) {
+            bh.consume(state.jaroWinklerSimilarity.apply(query));
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private JaroWinklerSimilarity jaroWinklerSimilarity;
+        private List<String> queriesSample;
+
+        @Setup
+        public void setup() {
+            List<String> dataset = loadDataset();
+            this.jaroWinklerSimilarity = JaroWinklerSimilarity.with(dataset, SIMILARITY_THRESHOLD);
+            this.queriesSample = IntStream.range(0, dataset.size() / QUERIES_SAMPLE_SIZE)
+                    .mapToObj(i -> dataset.get(i * QUERIES_SAMPLE_SIZE))
+                    .collect(Collectors.toList());
+        }
+
+        private List<String> loadDataset() {
+            try (GZIPInputStream gis = new GZIPInputStream(this.getClass().getClassLoader().getResourceAsStream(DATASET_PATH));
+                 InputStreamReader isr = new InputStreamReader(gis, StandardCharsets.UTF_8);
+                 BufferedReader br = new BufferedReader(isr)) {
+
+                String line = br.readLine();
+                List<String> dataset = new ArrayList<>();
+                while (line != null) {
+                    dataset.add(line);
+                    line = br.readLine();
+                }
+
+                return dataset;
+            } catch (IOException ex) {
+                throw new RuntimeException("failed to load dataset", ex);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Context

Reduces memory allocation by 80% and increases throughput by 20% as well.

Here are the benchmark results on my Apple Air M1.

```
# JMH version: 1.36
# VM version: JDK 17.0.1, OpenJDK 64-Bit Server VM, 17.0.1+12
# VM invoker: ...java/17.0.1-tem/bin/java


# Before
Benchmark                                                      Mode  Cnt            Score    Error   Units
JaroWinklerSimilarityBenchmark.benchmark                      thrpt   15            0.082 ±  0.002   ops/s
JaroWinklerSimilarityBenchmark.benchmark:·gc.alloc.rate       thrpt   15         1006.070 ± 27.086  MB/sec
JaroWinklerSimilarityBenchmark.benchmark:·gc.alloc.rate.norm  thrpt   15  12926893363.733 ± 82.405    B/op
JaroWinklerSimilarityBenchmark.benchmark:·gc.count            thrpt   15          277.000           counts
JaroWinklerSimilarityBenchmark.benchmark:·gc.time             thrpt   15          168.000               ms

# After
Benchmark                                                      Mode  Cnt           Score     Error   Units
JaroWinklerSimilarityBenchmark.benchmark                      thrpt   15           0.099 ±   0.002   ops/s
JaroWinklerSimilarityBenchmark.benchmark:·gc.alloc.rate       thrpt   15         194.065 ±   3.370  MB/sec
JaroWinklerSimilarityBenchmark.benchmark:·gc.alloc.rate.norm  thrpt   15  2050897564.267 ± 127.669    B/op
JaroWinklerSimilarityBenchmark.benchmark:·gc.count            thrpt   15          55.000            counts
JaroWinklerSimilarityBenchmark.benchmark:·gc.time             thrpt   15          36.000                ms
```

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
